### PR TITLE
Add interactive grid layout and server

### DIFF
--- a/PortfolioServer.java
+++ b/PortfolioServer.java
@@ -1,0 +1,45 @@
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class PortfolioServer {
+    public static void main(String[] args) throws Exception {
+        int port = 8000;
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/", exchange -> {
+            String path = exchange.getRequestURI().getPath();
+            if (path.equals("/")) {
+                path = "index.html";
+            } else {
+                path = path.substring(1);
+            }
+            try {
+                byte[] bytes = Files.readAllBytes(Paths.get(path));
+                exchange.getResponseHeaders().add("Content-Type", contentType(path));
+                exchange.sendResponseHeaders(200, bytes.length);
+                OutputStream os = exchange.getResponseBody();
+                os.write(bytes);
+                os.close();
+            } catch (IOException e) {
+                String msg = "File not found";
+                exchange.sendResponseHeaders(404, msg.length());
+                exchange.getResponseBody().write(msg.getBytes());
+                exchange.getResponseBody().close();
+            }
+        });
+        server.start();
+        System.out.println("Server started on http://localhost:" + port);
+    }
+
+    private static String contentType(String path) {
+        if (path.endsWith(".html")) return "text/html";
+        if (path.endsWith(".css")) return "text/css";
+        if (path.endsWith(".js")) return "application/javascript";
+        if (path.endsWith(".png")) return "image/png";
+        if (path.endsWith(".jpg") || path.endsWith(".jpeg")) return "image/jpeg";
+        return "text/plain";
+    }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Arnaud Demuyt - Portfolio</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="background"></div>
+    <header>
+        <div class="container">
+            <div class="logo">Arnaud Demuyt</div>
+            <nav>
+                <a href="poetry.html">Poetry</a>
+                <a href="pictures.html">Pictures</a>
+                <a href="thoughts.html">Thoughts</a>
+                <a href="projects.html">Projects</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <h1>Arnaud Demuyt</h1>
+        <p class="tagline">About me</p>
+    </main>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/pictures.html
+++ b/pictures.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pictures - Arnaud Demuyt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="background"></div>
+    <header>
+        <div class="container">
+            <div class="logo">Arnaud Demuyt</div>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="poetry.html">Poetry</a>
+                <a href="thoughts.html">Thoughts</a>
+                <a href="projects.html">Projects</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <h1>Pictures</h1>
+        <div class="grid-container" id="picture-grid">
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+1" alt="Picture 1">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+1" alt="Picture 1">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+2" alt="Picture 2">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+2" alt="Picture 2">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+3" alt="Picture 3">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+3" alt="Picture 3">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+4" alt="Picture 4">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+4" alt="Picture 4">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+5" alt="Picture 5">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+5" alt="Picture 5">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+6" alt="Picture 6">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+6" alt="Picture 6">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+7" alt="Picture 7">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+7" alt="Picture 7">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+8" alt="Picture 8">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+8" alt="Picture 8">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+9" alt="Picture 9">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+9" alt="Picture 9">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+10" alt="Picture 10">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+10" alt="Picture 10">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+11" alt="Picture 11">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+11" alt="Picture 11">
+                </div>
+            </div>
+            <div class="card">
+                <img src="https://via.placeholder.com/300x200?text=Pic+12" alt="Picture 12">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+12" alt="Picture 12">
+                </div>
+            </div>
+            <div class="card hidden">
+                <img src="https://via.placeholder.com/300x200?text=Pic+13" alt="Picture 13">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+13" alt="Picture 13">
+                </div>
+            </div>
+            <div class="card hidden">
+                <img src="https://via.placeholder.com/300x200?text=Pic+14" alt="Picture 14">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+14" alt="Picture 14">
+                </div>
+            </div>
+            <div class="card hidden">
+                <img src="https://via.placeholder.com/300x200?text=Pic+15" alt="Picture 15">
+                <div class="full-content">
+                    <img src="https://via.placeholder.com/800x600?text=Pic+15" alt="Picture 15">
+                </div>
+            </div>
+        </div>
+        <button class="load-more" data-target="#picture-grid">Load more</button>
+    </main>
+    <div id="modal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <div class="modal-body"></div>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/poetry.html
+++ b/poetry.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Poetry - Arnaud Demuyt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="background"></div>
+    <header>
+        <div class="container">
+            <div class="logo">Arnaud Demuyt</div>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="pictures.html">Pictures</a>
+                <a href="thoughts.html">Thoughts</a>
+                <a href="projects.html">Projects</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <h1>Poetry</h1>
+        <div class="grid-container" id="poetry-grid">
+            <div class="card">
+                <p>Poem 1 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 1 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 2 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 2 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 3 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 3 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 4 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 4 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 5 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 5 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 6 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 6 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 7 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 7 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 8 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 8 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 9 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 9 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 10 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 10 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 11 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 11 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Poem 12 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 12 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Poem 13 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 13 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Poem 14 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 14 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Poem 15 snippet...</p>
+                <div class="full-content">
+                    <p>Full text of poem 15 goes here. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+        </div>
+        <button class="load-more" data-target="#poetry-grid">Load more</button>
+    </main>
+    <div id="modal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <div class="modal-body"></div>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Projects - Arnaud Demuyt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="background"></div>
+    <header>
+        <div class="container">
+            <div class="logo">Arnaud Demuyt</div>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="poetry.html">Poetry</a>
+                <a href="pictures.html">Pictures</a>
+                <a href="thoughts.html">Thoughts</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <h1>Projects</h1>
+        <div class="grid-container" id="projects-grid">
+            <div class="card">
+                <p>Project 1 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 1. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 2 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 2. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 3 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 3. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 4 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 4. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 5 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 5. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 6 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 6. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 7 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 7. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 8 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 8. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 9 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 9. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 10 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 10. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 11 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 11. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Project 12 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 12. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Project 13 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 13. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Project 14 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 14. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Project 15 overview...</p>
+                <div class="full-content">
+                    <p>Details about project 15. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+        </div>
+        <button class="load-more" data-target="#projects-grid">Load more</button>
+    </main>
+    <div id="modal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <div class="modal-body"></div>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.load-more').forEach(btn => {
+        btn.addEventListener('click', () => {
+            const grid = document.querySelector(btn.dataset.target);
+            if (grid) {
+                grid.querySelectorAll('.hidden').forEach(el => el.classList.remove('hidden'));
+            }
+            btn.remove();
+        });
+    });
+
+    const modal = document.getElementById('modal');
+    if (modal) {
+        const modalBody = modal.querySelector('.modal-body');
+        modal.querySelector('.close').addEventListener('click', () => {
+            modal.style.display = 'none';
+        });
+
+        document.querySelectorAll('.card').forEach(card => {
+            card.addEventListener('click', () => {
+                const content = card.querySelector('.full-content').innerHTML;
+                modalBody.innerHTML = content;
+                modal.style.display = 'flex';
+            });
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,200 @@
+* {
+    box-sizing: border-box;
+    margin: 0;
+    padding: 0;
+}
+
+html, body {
+    height: 100%;
+    font-family: Arial, Helvetica, sans-serif;
+}
+
+body {
+    position: relative;
+    color: #fff;
+    overflow-x: hidden;
+}
+
+.background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow: hidden;
+    z-index: -1;
+}
+
+.background::before,
+.background::after {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTI4MCIgaGVpZ2h0PSI3MjAiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+PHBhdGggZmlsbD0iI2ZmZiIgZmlsbC1vcGFjaXR5PSIuMyIgZD0ibTAgMTIwIHMzMjAgMjkwIDY0MCAwIDY0MCAyOTAgNjQwIDAgNjQwIDI5MCA2NDAgMCIvPjwvc3ZnPg==') repeat-x;
+    animation: wave 10s linear infinite;
+    opacity: 0.6;
+}
+
+.background::after {
+    animation-duration: 15s;
+    opacity: 0.4;
+}
+
+@keyframes wave {
+    from { transform: translateX(0); }
+    to { transform: translateX(-50%); }
+}
+
+header {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    padding: 20px 0;
+}
+
+header .container {
+    max-width: 900px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background-color: rgba(0,0,0,0.4);
+    padding: 10px 20px;
+    border-radius: 8px;
+    backdrop-filter: blur(5px);
+}
+
+.logo {
+    font-size: 1.5em;
+    font-weight: bold;
+}
+
+nav a {
+    margin: 0 10px;
+    color: #fff;
+    text-decoration: none;
+    position: relative;
+    padding: 5px 0;
+}
+
+nav a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -2px;
+    width: 100%;
+    height: 2px;
+    background: #fff;
+    transform: scaleX(0);
+    transform-origin: right;
+    transition: transform 0.3s ease;
+}
+
+nav a:hover::after {
+    transform: scaleX(1);
+    transform-origin: left;
+}
+
+main {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: 20px;
+}
+
+h1 {
+    font-size: 3em;
+    margin-bottom: 0.5em;
+}
+
+.tagline {
+    font-size: 1.2em;
+    max-width: 500px;
+}
+.grid-container {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+    gap: 20px;
+    padding: 20px;
+}
+
+.card {
+    background: #fff9a9;
+    color: #333;
+    padding: 15px;
+    border-radius: 8px;
+    box-shadow: 0 2px 5px rgba(0,0,0,0.2);
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.card:hover {
+    transform: scale(1.05);
+}
+
+.card img {
+    width: 100%;
+    height: auto;
+    display: block;
+    margin-bottom: 10px;
+}
+
+.hidden {
+    display: none;
+}
+
+.load-more {
+    display: block;
+    margin: 20px auto;
+    padding: 10px 20px;
+    background: rgba(255,255,255,0.8);
+    border: none;
+    cursor: pointer;
+    border-radius: 4px;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0,0,0,0.8);
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+.modal-content {
+    background: #fff;
+    padding: 20px;
+    border-radius: 8px;
+    position: relative;
+    max-width: 90%;
+    max-height: 90%;
+    overflow: auto;
+}
+
+.modal-content img {
+    max-width: 100%;
+    height: auto;
+}
+
+.modal-content .close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    font-size: 1.5em;
+    cursor: pointer;
+}
+.full-content {
+    display: none;
+}

--- a/thoughts.html
+++ b/thoughts.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Thoughts - Arnaud Demuyt</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <div class="background"></div>
+    <header>
+        <div class="container">
+            <div class="logo">Arnaud Demuyt</div>
+            <nav>
+                <a href="index.html">Home</a>
+                <a href="poetry.html">Poetry</a>
+                <a href="pictures.html">Pictures</a>
+                <a href="projects.html">Projects</a>
+            </nav>
+        </div>
+    </header>
+    <main>
+        <h1>Thoughts</h1>
+        <div class="grid-container" id="thoughts-grid">
+            <div class="card">
+                <p>Thought 1 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 1 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 2 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 2 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 3 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 3 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 4 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 4 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 5 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 5 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 6 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 6 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 7 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 7 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 8 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 8 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 9 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 9 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 10 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 10 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 11 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 11 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card">
+                <p>Thought 12 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 12 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Thought 13 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 13 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Thought 14 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 14 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+            <div class="card hidden">
+                <p>Thought 15 preview...</p>
+                <div class="full-content">
+                    <p>Full thought 15 text. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                </div>
+            </div>
+        </div>
+        <button class="load-more" data-target="#thoughts-grid">Load more</button>
+    </main>
+    <div id="modal" class="modal">
+        <div class="modal-content">
+            <span class="close">&times;</span>
+            <div class="modal-body"></div>
+        </div>
+    </div>
+    <script src="script.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add grid/post-it styles and modal overlay to `style.css`
- implement load-more and modal logic in `script.js`
- expand Pictures, Poetry, Projects and Thoughts pages with card grids
- include simple `PortfolioServer.java` to host the site

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `javac PortfolioServer.java`


------
https://chatgpt.com/codex/tasks/task_e_686d13d2040c8324b69ef2fecaf8ead1